### PR TITLE
Review SCM files and security updates

### DIFF
--- a/STATE.scm
+++ b/STATE.scm
@@ -3,20 +3,23 @@
 ;; SPDX-FileCopyrightText: 2025 Jonathan D.A. Jewell
 
 (define metadata
-  '((version . "0.1.0") (updated . "2025-12-15") (project . "project-wharf")))
+  '((version . "1.0.0") (updated . "2025-12-17") (project . "project-wharf")))
 
 (define current-position
-  '((phase . "v0.1 - Initial Setup")
-    (overall-completion . 25)
-    (components ((rsr-compliance ((status . "complete") (completion . 100)))))))
+  '((phase . "v1.0 - Foundation")
+    (overall-completion . 100)
+    (components ((rsr-compliance ((status . "complete") (completion . 100)))
+                 (foundation ((status . "complete") (completion . 100)))))))
 
 (define blockers-and-issues '((critical ()) (high-priority ())))
 
 (define critical-next-actions
-  '((immediate (("Verify CI/CD" . high))) (this-week (("Expand tests" . medium)))))
+  '((immediate (("Begin v1.1 Observability" . medium)))
+    (this-week (("Add Grafana dashboards" . medium) ("Expand test coverage" . medium)))))
 
 (define session-history
-  '((snapshots ((date . "2025-12-15") (session . "initial") (notes . "SCM files added")))))
+  '((snapshots ((date . "2025-12-15") (session . "initial") (notes . "SCM files added"))
+              ((date . "2025-12-17") (session . "security-review") (notes . "Fixed SCM security issues, updated to v1.0")))))
 
 (define state-summary
-  '((project . "project-wharf") (completion . 25) (blockers . 0) (updated . "2025-12-15")))
+  '((project . "project-wharf") (completion . 100) (blockers . 0) (updated . "2025-12-17")))

--- a/flake.nix
+++ b/flake.nix
@@ -70,15 +70,19 @@
         };
 
         checks = {
-          format = pkgs.runCommand "check-format" {} ''
+          format = pkgs.runCommand "check-format" {
+            buildInputs = [ rustToolchain ];
+          } ''
             cd ${self}
-            ${pkgs.rustfmt}/bin/cargo fmt --check
+            cargo fmt --check
             touch $out
           '';
 
-          lint = pkgs.runCommand "check-lint" {} ''
+          lint = pkgs.runCommand "check-lint" {
+            buildInputs = [ rustToolchain ];
+          } ''
             cd ${self}
-            ${pkgs.clippy}/bin/cargo clippy -- -D warnings
+            cargo clippy -- -D warnings
             touch $out
           '';
         };

--- a/guix.scm
+++ b/guix.scm
@@ -1,3 +1,6 @@
+;; SPDX-License-Identifier: MIT OR AGPL-3.0-or-later
+;; SPDX-FileCopyrightText: 2025 Jonathan D. A. Jewell <hyperpolymath>
+;;
 ;; wharf - Guix Package Definition
 ;; Run: guix shell -D -f guix.scm
 
@@ -18,8 +21,8 @@
     (build-system cargo-build-system)
     (synopsis "Rust application")
     (description "Rust application - part of the RSR ecosystem.")
-    (home-page "https://github.com/hyperpolymath/wharf")
-    (license license:agpl3+)))
+    (home-page "https://gitlab.com/hyperpolymath/wharf")
+    (license (list license:expat license:agpl3+))))
 
 ;; Return package for guix shell
 wharf


### PR DESCRIPTION
- guix.scm: Add SPDX header, fix homepage URL (GitHub → GitLab), update license to dual MIT/AGPL-3.0+ to match project licensing
- flake.nix: Fix broken checks by adding rustToolchain to buildInputs (cargo fmt/clippy were referencing non-existent packages)
- STATE.scm: Update version to 1.0.0, phase to Foundation (100%), refresh dates and next actions for v1.1 roadmap