### PR TITLE
docs(flake): annotate KEEP+DEP rationale (standards#102)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,17 @@
 #
 # Project Wharf - Nix Flake
 # Reproducible development environment and builds
+#
+# Retained per standards#102 rule 3 (KEEP+DEP). guix.scm uses
+# cargo-build-system with no declared inputs; the sealed Containerfile
+# (Chainguard Wolfi) installs only `rust cargo pkgconf openssl-dev`.
+# This flake's devShell is therefore the SOLE source of: the
+# rust-overlay rustToolchain (with rust-src + rust-analyzer), the Rust
+# auditing/QA chain (cargo-audit, cargo-tarpaulin, cargo-watch),
+# task/build tooling (just, jq), DNS tooling (bind), security tooling
+# (nebula), docs (asciidoctor), linting (codespell, lychee), and the
+# container CLI (podman). Remove only once those are reachable via
+# Guix or the sealed container.
 
 {
   description = "Wharf - The Sovereign Web Hypervisor";


### PR DESCRIPTION
Refs standards#101 standards#102.

Per the [Nix-mirror retirement campaign](https://github.com/hyperpolymath/standards/issues/102) (Wave 11), `project-wharf`'s flake is **LOAD-BEARING** (KEEP+DEP): the dev shell is the sole source of the rust-overlay rustToolchain (with rust-src/rust-analyzer), the Rust auditing/QA chain (cargo-audit/tarpaulin/watch), task/build tooling (just, jq), DNS tooling (bind), security tooling (nebula), docs (asciidoctor), linting (codespell, lychee), and the container CLI (podman). `guix.scm` declares no inputs; the sealed Containerfile (Wolfi) covers only rust/cargo/pkgconf/openssl-dev.

This PR adds the rule-3 annotation so the flake's retention is self-documenting. No package-set change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)