### PR TITLE
chore(licence): migrate Cargo.toml from PMPL-1.0 to MPL-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 authors = ["Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>"]
-license = "PMPL-1.0"
+license = "MPL-2.0"
 repository = "https://gitlab.com/hyperpolymath/wharf"
 description = "The Sovereign Web Hypervisor - Immutable CMS Infrastructure"
 


### PR DESCRIPTION
## Summary
- Updates `Cargo.toml` license field from `PMPL-1.0` to `MPL-2.0`.
- Closes the SPDX-vs-manifest mismatch flagged by [standards#196](https://github.com/hyperpolymath/standards/pull/196) (estate licence-debt audit, 2026-05-26).
- Aligns this repo with the estate policy of `MPL-1.0/PMPL-1.0 → MPL-2.0` migration.

## What this PR does NOT do
This is the manifest field only. The LICENSE file (if it carries a Palimpsest preamble) keeps that preamble — the load-bearing MPL-2.0 text is unchanged.

## Companion
- standards#196 — licence debt audit
- standards#201 — licence-consistency CI check (will catch future drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)