### PR TITLE
ci(hypatia-scan): repin reusable to merge-commit SHA (orphan-SHA fix)

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@915139d73560e65a8240b8fc7768698658502c89
     secrets: inherit


### PR DESCRIPTION
## Summary

The `hypatia-scan.yml` wrapper pins to `97df762...` — the **PR-branch** commit of standards#193, not its merge commit. After the squash-merge, that PR-branch SHA was orphaned. GitHub Actions can no longer resolve the reusable, so every hypatia-scan run fails at parse stage (`jobs: []`, banner: "This run likely failed because of a workflow file issue").

## Diagnosis

- Old pin: `97df762107501909f50bb770e9bc200b6c415600` — PR-branch commit on standards#193 (orphaned).
- New pin: `915139d73560e65a8240b8fc7768698658502c89` — actual merge-commit on standards/main.

Verification:

```
$ gh api repos/hyperpolymath/standards/compare/main...97df762
{ "status": "diverged", "ahead_by": 1, "behind_by": 24 }
$ gh api repos/hyperpolymath/standards/compare/main...915139d7
{ "status": "behind", "ahead_by": 0, "behind_by": 1 }
```

File content at both SHAs is byte-identical; only the reachability differs.

## Estate scope

This is one of ~100 PRs in the sweep (`gh search code "@97df762" --owner hyperpolymath` returned 100 hits). Reusables-campaign closure track. See `hyperpolymath/standards#220` for the closure audit doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)