### PR TITLE
fix(ci): drop beta-Rust CodeQL leg (cancelled/hanging 'checks 2 things forever')

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,6 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: rust
-          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## What

The CodeQL matrix analysed a `rust` leg. **CodeQL Rust support is beta** — that leg cancels/hangs and never resolves (the recurring *"CodeQL checks 2 things forever"* symptom), providing zero real security coverage.

## Fix

Remove the `rust` leg; keep/ensure an `actions` leg so the matrix stays non-empty (no zero-jobs `startup_failure`). Rust security belongs in native tooling (cargo-audit / clippy), not beta CodeQL.

## Verification

`actionlint`: no parse/syntax errors; matrix has an `actions` leg and zero active `rust` legs.

## Context

Estate-wide shared-fate: 13 repos carried this beta-Rust CodeQL leg. Reference: hyperpolymath/gitbot-fleet#375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)